### PR TITLE
feat: add new formation templates and unit test for graph isomorphism

### DIFF
--- a/fasr/pom.xml
+++ b/fasr/pom.xml
@@ -14,6 +14,12 @@
             <artifactId>jgrapht-core</artifactId>
             <version>1.5.2</version>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.8.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 

--- a/fasr/src/main/java/de/ljunker/fasr/model/FormationTemplates.java
+++ b/fasr/src/main/java/de/ljunker/fasr/model/FormationTemplates.java
@@ -5,7 +5,7 @@ import de.ljunker.fasr.model.connection.FacingDancerViewConnection;
 
 public class FormationTemplates {
 
-  public static FasrGraph LinesNorthSouth() {
+  public static FasrGraph Lines() {
     FasrGraph graph = new FasrGraph();
     Dancer B1 = new Dancer("B1", Dancer.Gender.BOY);
     Dancer B2 = new Dancer("B2", Dancer.Gender.BOY);
@@ -27,10 +27,43 @@ public class FormationTemplates {
     graph.addEdge(B2, G2, new CoupleHandConnection());
     graph.addEdge(B3, G3, new CoupleHandConnection());
     graph.addEdge(B4, G4, new CoupleHandConnection());
+    graph.addEdge(G1, B2, new CoupleHandConnection());
+    graph.addEdge(G3, B4, new CoupleHandConnection());
     graph.addEdge(B1, G4, new FacingDancerViewConnection(B1, G4));
-    graph.addEdge(G2, B4, new FacingDancerViewConnection(G2, B4));
+    graph.addEdge(G1, B4, new FacingDancerViewConnection(G1, B4));
     graph.addEdge(B2, G3, new FacingDancerViewConnection(B2, G3));
     graph.addEdge(G2, B3, new FacingDancerViewConnection(G2, B3));
+    return graph;
+  }
+
+  public static FasrGraph LinesTwoCouplesTraded() {
+    FasrGraph graph = new FasrGraph();
+    Dancer B1 = new Dancer("B1", Dancer.Gender.BOY);
+    Dancer B2 = new Dancer("B2", Dancer.Gender.BOY);
+    Dancer B3 = new Dancer("B3", Dancer.Gender.BOY);
+    Dancer B4 = new Dancer("B4", Dancer.Gender.BOY);
+    Dancer G1 = new Dancer("G1", Dancer.Gender.GIRL);
+    Dancer G2 = new Dancer("G2", Dancer.Gender.GIRL);
+    Dancer G3 = new Dancer("G3", Dancer.Gender.GIRL);
+    Dancer G4 = new Dancer("G4", Dancer.Gender.GIRL);
+    graph.addVertex(B1);
+    graph.addVertex(B2);
+    graph.addVertex(B3);
+    graph.addVertex(B4);
+    graph.addVertex(G1);
+    graph.addVertex(G2);
+    graph.addVertex(G3);
+    graph.addVertex(G4);
+    graph.addEdge(B1, G1, new CoupleHandConnection());
+    graph.addEdge(B2, G2, new CoupleHandConnection());
+    graph.addEdge(B3, G3, new CoupleHandConnection());
+    graph.addEdge(B4, G4, new CoupleHandConnection());
+    graph.addEdge(G2, B1, new CoupleHandConnection());
+    graph.addEdge(G3, B4, new CoupleHandConnection());
+    graph.addEdge(B1, G3, new FacingDancerViewConnection(B1, G3));
+    graph.addEdge(G1, B3, new FacingDancerViewConnection(G1, B3));
+    graph.addEdge(B2, G4, new FacingDancerViewConnection(B2, G4));
+    graph.addEdge(G2, B4, new FacingDancerViewConnection(G2, B4));
     return graph;
   }
 }

--- a/fasr/src/test/java/de/ljunker/fasr/analysis/GraphMatcherTest.java
+++ b/fasr/src/test/java/de/ljunker/fasr/analysis/GraphMatcherTest.java
@@ -1,0 +1,23 @@
+package de.ljunker.fasr.analysis;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import de.ljunker.fasr.model.Dancer;
+import de.ljunker.fasr.model.FasrGraph;
+import de.ljunker.fasr.model.FormationTemplates;
+import org.junit.jupiter.api.Test;
+
+class GraphMatcherTest {
+
+  @Test
+  void testIsIsomorphic() {
+    FasrGraph graph1 = FormationTemplates.Lines();
+    FasrGraph graph2 = FormationTemplates.LinesTwoCouplesTraded();
+
+    assertTrue(GraphMatcher.isIsomorphic(graph1, graph2));
+  }
+
+  private static Dancer getDancer(FasrGraph graph1, String name) {
+    return graph1.vertexSet().stream().filter(d -> d.name.equals(name)).findFirst().get();
+  }
+
+}


### PR DESCRIPTION
- Added `LinesTwoCouplesTraded` formation in `FormationTemplates`.
- Updated connections in `Lines` formation.
- Introduced `junit-jupiter` library for testing in `pom.xml`.
- Created `GraphMatcherTest` for verifying graph isomorphism.